### PR TITLE
Fix order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.github.Podzilla</groupId>
 			<artifactId>podzilla-utils-lib</artifactId>
-			<version>v1.1.12</version>
+			<version>v1.1.13</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/podzilla/order/controller/OrderController.java
+++ b/src/main/java/com/podzilla/order/controller/OrderController.java
@@ -1,5 +1,11 @@
 package com.podzilla.order.controller;
 
+import com.podzilla.mq.EventPublisher;
+import com.podzilla.mq.EventsConstants;
+import com.podzilla.mq.events.CartCheckedoutEvent;
+import com.podzilla.mq.events.ConfirmationType;
+import com.podzilla.mq.events.DeliveryAddress;
+import com.podzilla.mq.events.OrderItem;
 import com.podzilla.order.model.Order;
 import com.podzilla.order.model.OrderLocation;
 import com.podzilla.order.model.OrderStatus;
@@ -22,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,12 +40,14 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderService orderService;
+    private final EventPublisher eventPublisher;
     private static final Logger LOGGER =
             LoggerFactory.getLogger(OrderController.class);
 
     @Autowired
-    public OrderController(final OrderService orderService) {
+    public OrderController(final OrderService orderService, final EventPublisher eventPublisher) {
         this.orderService = orderService;
+        this.eventPublisher = eventPublisher;
     }
 
 
@@ -78,6 +88,33 @@ public class OrderController {
         return ResponseEntity.ok(order);
     }
 
+
+    @GetMapping("/testEventPublisher")
+    public ResponseEntity<String> testEventPublisher() {
+        LOGGER.info("Testing Event Publisher");
+        List<OrderItem> orderItems = new ArrayList<>();
+        orderItems.add(new OrderItem(UUID.randomUUID().toString(), 5, new BigDecimal(100.0)));
+        DeliveryAddress deliveryAddress = new DeliveryAddress(
+                "123 Main St",
+                "Springfield",
+                "IL",
+                "USA",
+                "62701"
+        );
+        CartCheckedoutEvent event = new CartCheckedoutEvent(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                orderItems,
+                new BigDecimal(500.0),
+                deliveryAddress,
+                10.0,
+                20.0,
+                "signature",
+                ConfirmationType.SIGNATURE
+        );
+        eventPublisher.publishEvent(EventsConstants.CART_CHECKEDOUT, event);
+        return ResponseEntity.ok("Event published successfully");
+    }
 
 
     @PatchMapping("/{id}")
@@ -122,7 +159,6 @@ public class OrderController {
         LOGGER.info("Order found for user ID: {}", userId);
         return ResponseEntity.ok(order);
     }
-
 
 
     @PutMapping("/cancel/{id}")

--- a/src/main/java/com/podzilla/order/messaging/OrderProducer.java
+++ b/src/main/java/com/podzilla/order/messaging/OrderProducer.java
@@ -40,4 +40,6 @@ public class OrderProducer {
                 orderCancelledEvent
         );
     }
+
+
 }

--- a/src/main/java/com/podzilla/order/model/Address.java
+++ b/src/main/java/com/podzilla/order/model/Address.java
@@ -1,13 +1,7 @@
 package com.podzilla.order.model;
 
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -31,7 +25,7 @@ public class Address {
     private String country;
     private String postalCode;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 }

--- a/src/main/java/com/podzilla/order/service/OrderService.java
+++ b/src/main/java/com/podzilla/order/service/OrderService.java
@@ -53,6 +53,8 @@ public class OrderService {
         log.info("Creating new order: {}", order);
         order.setCreatedAt(LocalDateTime.now());
         order.setUpdatedAt(LocalDateTime.now());
+        order.getShippingAddress().setOrder(order);
+        order.getOrderProducts().forEach(product -> product.setOrder(order));
         orderRepository.save(order);
 
         OrderStatusStrategy strategy = strategyFactory.getStrategy(OrderStatus.PENDING);

--- a/src/main/java/com/podzilla/order/service/statusstrategy/CreatedOrderStrategy.java
+++ b/src/main/java/com/podzilla/order/service/statusstrategy/CreatedOrderStrategy.java
@@ -39,7 +39,7 @@ public class CreatedOrderStrategy implements OrderStatusStrategy {
         List<OrderProduct> orderProducts = order.getOrderProducts();
         for (OrderProduct product : orderProducts) {
             OrderItem orderItem = new OrderItem();
-            orderItem.setProductId(product.getId().toString());
+            orderItem.setProductId(product.getProductId().toString());
             orderItem.setQuantity(product.getQuantity());
             orderItem.setPricePerUnit(product.getPricePerUnit());
             orderItems.add(orderItem);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,10 @@ spring.rabbitmq.host=rabbitmq
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.generate-ddl=true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality, improve data consistency, and configure the application for better development and debugging. The most important updates include adding an event publishing mechanism, modifying entity relationships, updating dependency versions, and enhancing application properties for database configuration and debugging.

### Event Publishing and Controller Enhancements:
* [`OrderController`](diffhunk://#diff-8832907da751914ebafd26f08445330c5c60ae9f15305376afaffe5d3f38e93aR3-R8): Introduced an `EventPublisher` dependency and a new endpoint `/testEventPublisher` to test publishing `CartCheckedoutEvent` messages. This includes creating and publishing events with details such as order items, delivery address, and confirmation type. [[1]](diffhunk://#diff-8832907da751914ebafd26f08445330c5c60ae9f15305376afaffe5d3f38e93aR3-R8) [[2]](diffhunk://#diff-8832907da751914ebafd26f08445330c5c60ae9f15305376afaffe5d3f38e93aR43-R50) [[3]](diffhunk://#diff-8832907da751914ebafd26f08445330c5c60ae9f15305376afaffe5d3f38e93aR92-R118)

### Entity Relationship Updates:
* `Address` model: Changed the relationship with `Order` from `@ManyToOne` to `@OneToOne` to reflect a one-to-one mapping between an order and its shipping address.
* [`OrderService`](diffhunk://#diff-c27f9c0c7bb738a8f25418a39170326eaabc8fa2ed2f10a014dd260bfd0078aaR56-R57): Updated `createOrder` to ensure the `Order` entity sets bidirectional relationships for `shippingAddress` and `orderProducts` before saving.

### Dependency and Version Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L94-R94): Updated `podzilla-utils-lib` dependency version from `v1.1.12` to `v1.1.13`.

### Bug Fixes:
* [`CreatedOrderStrategy`](diffhunk://#diff-d8938b24804331f389727b7b38793d967427b80563cfe427a3b5b0bb061fcfb7L42-R42): Corrected the mapping of `OrderItem.productId` to use `OrderProduct.getProductId()` instead of `OrderProduct.getId()`.

### Application Configuration:
* [`application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R7-R13): Added JPA and Hibernate configurations to enable SQL debugging, format SQL output, and use PostgreSQL as the database platform.